### PR TITLE
Add document indexing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Pour installer les dépendances système et Python :
 bash install.sh
 ```
 
+Pour indexer vos documents :
+
+```bash
+python src/ingestion/index_documents.py data/
+```
+
 Après indexation des documents :
 
 ```bash

--- a/src/ingestion/index_documents.py
+++ b/src/ingestion/index_documents.py
@@ -1,0 +1,47 @@
+import argparse
+import os
+from pathlib import Path
+from uuid import uuid4
+
+from . import load_file
+from src.embeddings.embedder import Embedder
+from src.vectorstore.chroma_manager import ChromaManager
+
+
+def chunk_text(text: str, size: int = 1000, overlap: int = 200):
+    """Simple generator yielding chunks of text."""
+    step = size - overlap
+    for start in range(0, len(text), step):
+        yield text[start:start + size]
+
+
+def index_directory(directory: str):
+    embedder = Embedder()
+    store = ChromaManager()
+
+    for root, _, files in os.walk(directory):
+        for name in files:
+            path = Path(root) / name
+            try:
+                content = load_file(str(path))
+            except Exception as e:
+                print(f"Skipped {path}: {e}")
+                continue
+
+            chunks = list(chunk_text(content))
+            if not chunks:
+                continue
+
+            embeddings = embedder.encode(chunks)
+            ids = [str(uuid4()) for _ in chunks]
+            metadatas = [{"source": str(path), "chunk": i} for i in range(len(chunks))]
+
+            store.add(ids=ids, texts=chunks, embeddings=embeddings, metadatas=metadatas)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Index documents into ChromaDB")
+    parser.add_argument("directory", help="Directory containing files to index")
+    args = parser.parse_args()
+
+    index_directory(args.directory)


### PR DESCRIPTION
## Summary
- add `index_documents.py` script to ingest and embed files
- document indexing command in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a5ec241608322b93387b7bea4e768