### PR TITLE
Fix empty search results in chatbot

### DIFF
--- a/src/chatbot/utils.py
+++ b/src/chatbot/utils.py
@@ -1,0 +1,12 @@
+from typing import Any, Dict
+
+
+def extract_context(results: Dict[str, Any] | None) -> str:
+    """Extract a context string from Chroma search results."""
+    if not results:
+        return ""
+    docs = results.get("documents")
+    if docs and len(docs) > 0 and docs[0]:
+        # docs[0] is expected to be a list of strings
+        return "\n".join(docs[0])
+    return ""

--- a/tests/test_chatbot_utils.py
+++ b/tests/test_chatbot_utils.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+from src.chatbot.utils import extract_context
+
+
+def test_extract_context_empty():
+    assert extract_context(None) == ""
+    assert extract_context({}) == ""
+    assert extract_context({"documents": []}) == ""
+    assert extract_context({"documents": [[]]}) == ""
+
+
+def test_extract_context_with_docs():
+    results = {"documents": [["a", "b"]]}
+    assert extract_context(results) == "a\nb"


### PR DESCRIPTION
## Summary
- handle empty search results in Streamlit chatbot
- factor extraction logic into `extract_context`
- test extracting context from search results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a6e98cd908322a1818bc9be8256a0