### PR TITLE
Implement document indexing CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,11 @@ Pour indexer vos documents :
 
 ```bash
 python src/ingestion/index_documents.py data/
-bash run.sh
+# ou
+python src/ingestion/index_documents.py data/ --persist-dir my_chroma
 ```
+
+bash run.sh
 
 L'interface Streamlit sera alors accessible localement une fois le
 script `run.sh` lancé.

--- a/src/ingestion/index_documents.py
+++ b/src/ingestion/index_documents.py
@@ -9,15 +9,18 @@ from src.vectorstore.chroma_manager import ChromaManager
 
 
 def chunk_text(text: str, size: int = 1000, overlap: int = 200):
-    """Simple generator yielding chunks of text."""
+    """Yield consecutive chunks of ``size`` characters with ``overlap``."""
+
     step = size - overlap
     for start in range(0, len(text), step):
-        yield text[start:start + size]
+        yield text[start : start + size]
 
 
-def index_directory(directory: str):
+def index_directory(directory: str, persist_dir: str = "chroma_db"):
+    """Walk ``directory`` and index all supported files into ChromaDB."""
+
     embedder = Embedder()
-    store = ChromaManager()
+    store = ChromaManager(persist_dir=persist_dir)
 
     for root, _, files in os.walk(directory):
         for name in files:
@@ -36,12 +39,28 @@ def index_directory(directory: str):
             ids = [str(uuid4()) for _ in chunks]
             metadatas = [{"source": str(path), "chunk": i} for i in range(len(chunks))]
 
-            store.add(ids=ids, texts=chunks, embeddings=embeddings, metadatas=metadatas)
+            store.add(
+                ids=ids,
+                texts=chunks,
+                embeddings=embeddings,
+                metadatas=metadatas,
+            )
+
+
+def cli() -> None:
+    """Entry point for the command line."""
+
+    parser = argparse.ArgumentParser(description="Index documents into ChromaDB")
+    parser.add_argument("directory", help="Directory containing files to index")
+    parser.add_argument(
+        "--persist-dir",
+        default="chroma_db",
+        help="Destination directory for the Chroma database",
+    )
+    args = parser.parse_args()
+
+    index_directory(args.directory, args.persist_dir)
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Index documents into ChromaDB")
-    parser.add_argument("directory", help="Directory containing files to index")
-    args = parser.parse_args()
-
-    index_directory(args.directory)
+    cli()


### PR DESCRIPTION
## Summary
- enhance `index_documents.py` with optional `--persist-dir` and CLI function
- show example usage with custom persist directory in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a6e9bcae0832281f80b803b644d99